### PR TITLE
Fix configuration

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -39,7 +39,7 @@ jobs:
     
   tag_release:
     needs: [simple_deployment_pipeline]
-    if: github.event.pull_request.merged == true
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Check the branch before running tag_release job instead of checking github event.